### PR TITLE
enhance: Change Sort alias to Sort-Object

### DIFF
--- a/Get-WindowsUpdateFeed.ps1
+++ b/Get-WindowsUpdateFeed.ps1
@@ -89,4 +89,4 @@ ForEach ($e in $feedXml.feed.entry) {
     }
 }
 
-return ($feedEntries | Sort Published -Descending)
+return ($feedEntries | Sort-Object -Property Published -Descending)


### PR DESCRIPTION
Fixes issues when using command from a non-windows based OS as sort is
 a linux binary that gets called instead.
 
 Resolves #2 